### PR TITLE
Do not link to sqlite3 on macos

### DIFF
--- a/c_src/sqlite3_drv.c
+++ b/c_src/sqlite3_drv.c
@@ -400,7 +400,7 @@ static int changes(sqlite3_drv_t *drv, char *buf, int len) {
 }
 
 static int enable_load_extension(sqlite3_drv_t* drv, char *buf, int len) {
-#ifndef ERLANG_SQLITE3_NO_LOAD_EXTENSION
+#ifdef ERLANG_SQLITE3_LOAD_EXTENSION
   char enable = buf[0];
   int result = sqlite3_enable_load_extension(drv->db, (int) enable);
   if (result) {

--- a/c_src/sqlite3_drv.h
+++ b/c_src/sqlite3_drv.h
@@ -4,6 +4,7 @@
 #endif
 
 #define _CRT_SECURE_NO_WARNINGS // secure functions aren't cross-platform
+#define ERLANG_SQLITE3_LOAD_EXTENSION // comment out if SQLite is built with SQLITE_OMIT_LOAD_EXTENSION
 
 #include <erl_driver.h>
 #include <ei.h>

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,9 @@
 % -*- mode: erlang -*-
-{port_specs, [{"priv/sqlite3_drv.so", ["c_src/*.c"]},
+{port_specs, [{"^((?!darwin).)*$", "priv/sqlite3_drv.so", ["c_src/*.c"]},
               {"darwin", "priv/sqlite3_drv.so", ["c_src/*.c", "sqlite3_amalgamation/*.c"]}]}.
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes"},
-            {"DRV_LDFLAGS", "$DRV_LDFLAGS -lsqlite3"},
+            {"^((?!darwin|win32).)*$", "DRV_LDFLAGS", "$DRV_LDFLAGS -lsqlite3"},
             {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-            {".*darwin.*", "DRV_CFLAGS", "$DRV_CFLAGS -DERLANG_SQLITE3_NO_LOAD_EXTENSION"},
             {".*win32.*", "DRV_CFLAGS", "$DRV_CFLAGS /O2 /Isqlite3_amalgamation /Ic_src /W4 /wd4100 /wd4204 /wd4820 /wd4255 /wd4668 /wd4710 /wd4711"},
             {".*win32.*", "DRV_LDFLAGS", "$DRV_LDFLAGS sqlite3.lib"}]}.
 {cover_enabled, true}.


### PR DESCRIPTION
On macos (darwin), sqlite3 is embedded using "the amalgamation". There
is therefore no need to link to the system sqlite3, and doing so can
cause unexpected behaviour/failures.

Also be explicit about darwin vs. non-darwin port_specs sources.
rebar3 seems to get confused when compiling under eunit command sometimes